### PR TITLE
Provide feedback if correct API headers are not supplied

### DIFF
--- a/lib/killbill/resource.php
+++ b/lib/killbill/resource.php
@@ -114,11 +114,9 @@ abstract class Killbill_Resource /* implements JsonSerializable */ {
     public function _getFromBody() {
         $args = func_get_args();
         if (func_num_args() == 1) {
-            my_var_dump('at 1');
             $class = get_class($this);
             $response = $args[0];
         } else {
-            my_var_dump('at 2');
             $class = $args[0];
             $response = $args[1];
         }


### PR DESCRIPTION
When getting started with this API, it took me some debugging to find out that I wasn't setting $headers correctly (i.e. X-Killbill-ApiKey and X-Killbill-ApiSecret headers).  If you dump the response, it's null.

With this patch, you'll get this response:

array(2) {
  ["statusCode"]=>
  int(401)
  ["body"]=>
  string(1541) "

HTTP ERROR 401

Problem accessing /1.0/kb/accounts/7cf19fd6-3f37-4055-8500-ec6549cd79f3. Reason:

```
Make sure to set the X-Killbill-ApiKey and X-Killbill-ApiSecret headers
```

Powered by Jetty://
