### PR TITLE
Php library revisions for 0.16.x

### DIFF
--- a/lib/killbill/bundle.php
+++ b/lib/killbill/bundle.php
@@ -45,4 +45,17 @@ class Killbill_Bundle extends Killbill_BundleAttributes {
             $user, $reason, $comment, $headers);
         return null;
     }
+
+    public function pause($date, $user, $reason, $comment, $headers = null) {
+        $this->_update(Killbill_Client::PATH_BUNDLES . '/' .
+            $this->bundleId . '/pause?requestedDate=' . $date, $user, $reason, $comment, $headers);
+        return null;
+    }
+
+    public function resume($date, $user, $reason, $comment, $headers = null) {
+        $this->_update(Killbill_Client::PATH_BUNDLES . '/' .
+            $this->bundleId . '/resume?requestedDate=' . $date, $user, $reason, $comment, $headers);
+        return null;
+    }
+
 }

--- a/lib/killbill/catalog.php
+++ b/lib/killbill/catalog.php
@@ -21,7 +21,7 @@ class Killbill_Catalog extends Killbill_CatalogAttributesSimple {
     private $fullCatalog;
 
     public function initialize($headers = null) {
-        $response = $this->_get(Killbill_Client::PATH_CATALOG . '/simpleCatalog', $headers);
+        $response = $this->_get(Killbill_Client::PATH_CATALOG, $headers);
         $this->fullCatalog = json_decode($response->body);
     }
 

--- a/lib/killbill/gen/killbill_subscription_attributes.php
+++ b/lib/killbill/gen/killbill_subscription_attributes.php
@@ -41,7 +41,5 @@ class Killbill_SubscriptionAttributes extends Killbill_Resource {
   protected $billingStartDate;
   protected $billingEndDate;
   protected $events;
-  protected $newEvents;
-  protected $deletedEvents;
   protected $auditLogs;
 }

--- a/lib/killbill/tenant.php
+++ b/lib/killbill/tenant.php
@@ -23,7 +23,10 @@ class Killbill_Tenant extends Killbill_TenantAttributes
 
     public function get($headers = null)
     {
-        $response = $this->_get(Killbill_Client::PATH_TENANTS . '/' . $this->tenantId, $headers);
+
+        $response = $this->_get(Killbill_Client::PATH_TENANTS . ( isset($this->tenantId) ? '/' .$this->tenantId : '?apiKey=' . $this->$apiKey), $headers);
+
+
         return $this->_getFromBody('Killbill_Tenant', $response);
     }
 


### PR DESCRIPTION
These changes add Bundle Pause/Resume capability.
Also remove some redundant attributes which were causing errors because they were unexpected by the server.