### PR TITLE
Fix for fatal error

### DIFF
--- a/src/Tenant.php
+++ b/src/Tenant.php
@@ -33,7 +33,7 @@ class Tenant extends TenantAttributes
      */
     public function get($headers = null)
     {
-        $response = $this->getRequest(Client::PATH_TENANTS.((null !== $this->getTenantId()) ? '/'.$this->getTenantId() : '?apiKey='.$this->$apiKey), $headers);
+        $response = $this->getRequest(Client::PATH_TENANTS.((null !== $this->getTenantId()) ? '/'.$this->getTenantId() : '?apiKey='.$this->apiKey), $headers);
 
         try {
             /** @var Tenant|null $object */


### PR DESCRIPTION
This commit fixes a fatal error, which occurred when `null !== $this->getTenantId()` was `false`:
```
PHP Notice:  Undefined variable: apiKey in .../killbill-client/src/Tenant.php on line 36
PHP Fatal error:  Uncaught Error: Cannot access empty property in .../killbill-client/src/Tenant.php:36
```

Here's a short snippet to check the code works as expected:
```
Client::$serverUrl = 'http://127.0.0.1:8080';
Client::$apiUser = 'USER';
Client::$apiPassword = 'PASS';

$tenant = new Tenant();
$tenant->setApiKey('KEY');
$tenant->setApiSecret('SECRET');

var_dump($tenant->get($tenant->getTenantHeaders()));
```
