### PR TITLE
Fixed composer.json license value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "phpcs": "phpcs --standard=vendor/escapestudios/symfony2-coding-standard/Symfony2 ./src/ ./test/ --extensions=php --ignore=src/Type -d memory_limit=1024M",
     "phpcs-checkstyle": "phpcs --standard=vendor/escapestudios/symfony2-coding-standard/Symfony2 ./src/ ./test/ --extensions=php --ignore=src/Type -d memory_limit=1024M --report=checkstyle"
   },
-  "license": "Apache",
+  "license": "Apache-2.0",
   "require": {
     "php": "^5.5 || ^7.0",
     "ext-curl": "*",


### PR DESCRIPTION
This fixes #29 Invalid composer.json data.
An invalid license name was used.
`Apache-2.0` is used for [killbill/killbill](https://github.com/killbill/killbill), so I guess this is the correct value.

The output of composer validator:
```
$ composer validate
./composer.json is valid
```