### PR TITLE
Added test reproducing a bug where consumable addon prevents from generating the next invoice

### DIFF
--- a/src/AddAuthHeadersMiddleware.php
+++ b/src/AddAuthHeadersMiddleware.php
@@ -22,6 +22,7 @@ class AddAuthHeadersMiddleware
     private $whitelist = [
         ['GET|PUT', '/1.0/kb/tenants', [self::TENANT_KEY]],
         ['POST|PUT', '/1.0/kb/test/clock', [self::BASIC_AUTH, self::TENANT_KEY]],
+        ['GET', '/1.0/kb/test/queues', [self::BASIC_AUTH, self::TENANT_KEY]],
     ];
     /**
      * @param callable      $nextHandler

--- a/test/ServerClockMock.php
+++ b/test/ServerClockMock.php
@@ -28,6 +28,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class ServerClockMock
 {
+    const TIMEOUT_SEC = 120;
+
     /**
      * @var ClientInterface
      */
@@ -69,7 +71,7 @@ class ServerClockMock
         ]));
 
         // For precaution
-        usleep(3000000);
+        $this->waitForKillbill();
     }
 
     /**
@@ -82,6 +84,46 @@ class ServerClockMock
     public function addDays($count)
     {
         $this->incrementClock($count, null, null, null, 'UTC');
+    }
+
+    /**
+     * Wait for all available bus events and notifications to be processed
+     */
+    public function waitForKillbill()
+    {
+        $response = $this->client->get('test/queues', ['query' => ['timeout_sec' => 5]]);
+        if (200 !== $response->getStatusCode()) {
+            throw new ApiException(sprintf(
+                'Error calling test/queues. Status: %d, Message: %s',
+                $response->getStatusCode(),
+                $response->getBody()->getContents()
+            ));
+        }
+    }
+
+    /**
+     * @param mixed    $expected
+     * @param callable $callable
+     * @param array    $args
+     */
+    public function waitForExpectedClause($expected, callable $callable, array $args)
+    {
+        $starttime = microtime(true);
+        do {
+            $actual = call_user_func_array($callable, $args);
+            if ($expected === $actual) {
+                return;
+            }
+            usleep(1500000);
+            $elapsed = microtime(true) - $starttime;
+        } while ($elapsed < self::TIMEOUT_SEC);
+
+        throw new \RuntimeException(sprintf(
+            'Timeout after waiting %d sec. Expected: "%s", Actual: "%s"',
+            $elapsed,
+            $expected,
+            $actual
+        ));
     }
 
     /**
@@ -111,9 +153,8 @@ class ServerClockMock
         $this->assertResponse($this->client->put($uri, ['query' => $params]));
 
         // For precaution
-        usleep(3000000);
+        $this->waitForKillbill();
     }
-
 
     /**
      * @param ResponseInterface $response

--- a/test/ServerClockMock.php
+++ b/test/ServerClockMock.php
@@ -114,12 +114,12 @@ class ServerClockMock
             if ($expected === $actual) {
                 return;
             }
-            usleep(1500000);
+            $this->waitForKillbill();
             $elapsed = microtime(true) - $starttime;
         } while ($elapsed < self::TIMEOUT_SEC);
 
         throw new \RuntimeException(sprintf(
-            'Timeout after waiting %d sec. Expected: "%s", Actual: "%s"',
+            'Timeout after waiting for %d sec. Expected: "%s", Actual: "%s"',
             $elapsed,
             $expected,
             $actual

--- a/test/ServerInvoiceTest.php
+++ b/test/ServerInvoiceTest.php
@@ -280,4 +280,73 @@ class ServerInvoiceTest extends KillbillTest
 //        $cfs = $invoice->getCustomFields($this->tenant->getTenantHeaders());
 //        $this->assertEquals(2, count($cfs));
     }
+
+
+    public function testItShouldCreateInvoice_whenSubscribedOnBasePlan()
+    {
+        $subscriptionBase = new Subscription();
+        $subscriptionBase->setAccountId($this->account->getAccountId());
+        $subscriptionBase->setPlanName('sports-monthly');
+        $subscriptionBase = $this->client->getSubscriptionApi()->createSubscription($subscriptionBase, self::USER, self::REASON, self::COMMENT);
+        self::assertSame($this->account->getAccountId(), $subscriptionBase->getAccountId());
+        self::assertSame('sports-monthly', $subscriptionBase->getPlanName());
+
+        $invoices = $this->client->getAccountApi()->getInvoicesForAccount(
+            $this->account->getAccountId(),
+            null,
+            $withItems = 'true'
+        );
+        $this->assertCount(1, $invoices);
+        $this->assertSame(0.0, $invoices[0]->getAmount());
+
+        $this->clock->addDays(35);
+
+        $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount(
+            $this->account->getAccountId(),
+            null,
+            $withItems = 'true'
+        );
+        $this->assertCount(2, $invoicesNextMonth);
+        $this->assertSame(0.0, $invoicesNextMonth[0]->getAmount());
+        $this->assertSame(500.0, $invoicesNextMonth[1]->getAmount());
+    }
+
+    public function testItShouldCreateInvoice_whenSubscribedOnBasePlanAndConsumableAddon()
+    {
+        $subscriptionBase = new Subscription();
+        $subscriptionBase->setAccountId($this->account->getAccountId());
+        $subscriptionBase->setPlanName('sports-monthly');
+        $subscriptionBase = $this->client->getSubscriptionApi()->createSubscription($subscriptionBase, self::USER, self::REASON, self::COMMENT);
+        self::assertSame($this->account->getAccountId(), $subscriptionBase->getAccountId());
+        self::assertSame('sports-monthly', $subscriptionBase->getPlanName());
+
+        $subscriptionGas = new Subscription();
+        $subscriptionGas->setAccountId($this->account->getAccountId());
+        $subscriptionGas->setPlanName('gas-monthly');
+        $subscriptionGas->setBundleId($subscriptionBase->getBundleId());
+        $subscriptionGas = $this->client->getSubscriptionApi()->createSubscription($subscriptionGas, self::USER, self::REASON, self::COMMENT);
+        self::assertSame($this->account->getAccountId(), $subscriptionGas->getAccountId());
+        self::assertSame('gas-monthly', $subscriptionGas->getPlanName());
+
+        $invoices = $this->client->getAccountApi()->getInvoicesForAccount(
+            $this->account->getAccountId(),
+            null,
+            $withItems = 'true'
+        );
+        $this->assertCount(1, $invoices);
+        $this->assertSame(0.0, $invoices[0]->getAmount());
+
+        $this->clock->addDays(35);
+
+        $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount(
+            $this->account->getAccountId(),
+            null,
+            $withItems = 'true'
+        );
+        $this->assertCount(2, $invoicesNextMonth);
+        $this->assertSame(0.0, $invoicesNextMonth[0]->getAmount());
+        $this->assertSame(500.0, $invoicesNextMonth[1]->getAmount());
+
+    }
+
 }

--- a/test/ServerInvoiceTest.php
+++ b/test/ServerInvoiceTest.php
@@ -282,7 +282,10 @@ class ServerInvoiceTest extends KillbillTest
     }
 
 
-    public function testItShouldCreateInvoice_whenSubscribedOnBasePlan()
+    /**
+     * @test
+     */
+    public function itShouldCreateInvoiceWhenSubscribedOnBasePlan()
     {
         $subscriptionBase = new Subscription();
         $subscriptionBase->setAccountId($this->account->getAccountId());
@@ -311,7 +314,10 @@ class ServerInvoiceTest extends KillbillTest
         $this->assertSame(500.0, $invoicesNextMonth[1]->getAmount());
     }
 
-    public function testItShouldCreateInvoice_whenSubscribedOnBasePlanAndConsumableAddon()
+    /**
+     * @test
+     */
+    public function itShouldCreateInvoiceWhenSubscribedOnBasePlanAndConsumableAddon()
     {
         $subscriptionBase = new Subscription();
         $subscriptionBase->setAccountId($this->account->getAccountId());
@@ -346,7 +352,5 @@ class ServerInvoiceTest extends KillbillTest
         $this->assertCount(2, $invoicesNextMonth);
         $this->assertSame(0.0, $invoicesNextMonth[0]->getAmount());
         $this->assertSame(500.0, $invoicesNextMonth[1]->getAmount());
-
     }
-
 }

--- a/test/ServerInvoiceTest.php
+++ b/test/ServerInvoiceTest.php
@@ -303,6 +303,7 @@ class ServerInvoiceTest extends KillbillTest
         $this->assertSame(0.0, $invoices[0]->getAmount());
 
         $this->clock->addDays(35);
+        $this->clock->waitForExpectedClause(2, [$this, 'getAccountInvoicesNumber'], [$this->account->getAccountId()]);
 
         $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount(
             $this->account->getAccountId(),
@@ -344,6 +345,8 @@ class ServerInvoiceTest extends KillbillTest
 
         $this->clock->addDays(35);
 
+        $this->clock->waitForExpectedClause(2, [$this, 'getAccountInvoicesNumber'], [$this->account->getAccountId()]);
+
         $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount(
             $this->account->getAccountId(),
             null,
@@ -352,5 +355,14 @@ class ServerInvoiceTest extends KillbillTest
         $this->assertCount(2, $invoicesNextMonth);
         $this->assertSame(0.0, $invoicesNextMonth[0]->getAmount());
         $this->assertSame(500.0, $invoicesNextMonth[1]->getAmount());
+    }
+
+    /**
+     * @param string $accountId
+     * @return int
+     */
+    public function getAccountInvoicesNumber($accountId)
+    {
+        return count($this->client->getAccountApi()->getInvoicesForAccount($accountId));
     }
 }


### PR DESCRIPTION
Hello @pierre ,
Please take a look at these 2 tests.
First one subscribes a user to a base monthly plan and checks that the invoice is created after 1 month.
Second subscribes a user to the same base plan and consumable addon and makes the same checks. For some reason, the addon prevents from creating the invoice. Recording usages doesn't make difference.
