### PR TITLE
circleci: switch to MariaDB client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - checkout
       - restore_cache:
           key: v1-dependencies-{{ .Branch }}-{{ checksum "composer.json" }}
-      - run: sudo apt install -y curl mysql-client
+      - run: sudo apt install -y curl mariadb-client
       - run:
           name: Setup DDL
           command: |


### PR DESCRIPTION
This fixes #42.

@GregOriol Do you know how to pass the command line option `--log-junit` to PHPUnit so we can tell CircleCI about our tests (https://circleci.com/docs/2.0/collect-test-data/)?