### PR TITLE
Fixed tests and updated CI to v0.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/php:7.1-node-browsers
-      - image: killbill/killbill:0.20.10
+      - image: killbill/killbill:0.22.1
         environment:
           - KILLBILL_SERVER_TEST_MODE=true
-      - image: killbill/mariadb:0.20
+      - image: killbill/mariadb:0.22
         environment:
         - MYSQL_ROOT_PASSWORD=root
     steps:

--- a/.swagger-config.json
+++ b/.swagger-config.json
@@ -7,5 +7,5 @@
     "gitRepoId" : "killbill-client",
     "variableNamingConvention": "camelCase",
     "srcBasePath": "lib",
-    "httpUserAgent": "Killbill-Client/0.20.10/php"
+    "httpUserAgent": "Killbill-Client/0.22.1/php"
 }

--- a/test/ServerInvoiceTest.php
+++ b/test/ServerInvoiceTest.php
@@ -79,7 +79,7 @@ class ServerInvoiceTest extends KillbillTest
     {
         $subscriptionData = new Subscription();
         $subscriptionData->setAccountId($this->account->getAccountId());
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
         $subscriptionData->setProductName('Sports');
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
@@ -87,7 +87,7 @@ class ServerInvoiceTest extends KillbillTest
 
         $subscription = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
         $this->assertEquals($subscriptionData->getAccountId(), $subscription->getAccountId());
-        $this->assertEquals($subscriptionData->getExternalKey(), $subscription->getExternalKey());
+        $this->assertEquals($subscriptionData->getBundleExternalKey(), $subscription->getBundleExternalKey());
 
         $this->assertEquals('Sports', $subscription->getProductName());
         $this->assertEquals('BASE', $subscription->getProductCategory());
@@ -111,6 +111,8 @@ class ServerInvoiceTest extends KillbillTest
         $this->assertNotEmpty($invoice->getCurrency());
         $this->assertEquals($invoice->getAmount(), 0);
         $this->assertEquals($invoice->getBalance(), 0);
+        $this->assertCount(1, $invoice->getItems());
+        $this->assertEquals(0, $invoice->getItems()[0]->getAmount());
 
         //TODO: must be $withItems = true (w/o quotes)
         $invoice = $this->client->getInvoiceApi()->getInvoice($invoices[1]->getInvoiceId(), $withItems = 'true');
@@ -121,6 +123,9 @@ class ServerInvoiceTest extends KillbillTest
         $this->assertNotEmpty($invoice->getCurrency());
         $this->assertEquals($invoice->getAmount(), 500);
         $this->assertEquals($invoice->getBalance(), 0);
+        $this->assertNotEmpty($invoice->getItems());
+        $this->assertCount(1, $invoice->getItems());
+        $this->assertEquals(500, $invoice->getItems()[0]->getAmount());
     }
 
     /**
@@ -135,7 +140,7 @@ class ServerInvoiceTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscription = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
 
@@ -212,7 +217,7 @@ class ServerInvoiceTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscription = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
 
@@ -289,22 +294,14 @@ class ServerInvoiceTest extends KillbillTest
         self::assertSame($this->account->getAccountId(), $subscriptionBase->getAccountId());
         self::assertSame('sports-monthly', $subscriptionBase->getPlanName());
 
-        $invoices = $this->client->getAccountApi()->getInvoicesForAccount(
-            $this->account->getAccountId(),
-            null,
-            $withItems = 'true'
-        );
+        $invoices = $this->client->getAccountApi()->getInvoicesForAccount($this->account->getAccountId());
         $this->assertCount(1, $invoices);
         $this->assertSame(0.0, $invoices[0]->getAmount());
 
         $this->clock->addDays(35);
         $this->clock->waitForExpectedClause(2, [$this, 'getAccountInvoicesNumber'], [$this->account->getAccountId()]);
 
-        $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount(
-            $this->account->getAccountId(),
-            null,
-            $withItems = 'true'
-        );
+        $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount($this->account->getAccountId());
         $this->assertCount(2, $invoicesNextMonth);
         $this->assertSame(0.0, $invoicesNextMonth[0]->getAmount());
         $this->assertSame(500.0, $invoicesNextMonth[1]->getAmount());
@@ -330,11 +327,7 @@ class ServerInvoiceTest extends KillbillTest
         self::assertSame($this->account->getAccountId(), $subscriptionGas->getAccountId());
         self::assertSame('gas-monthly', $subscriptionGas->getPlanName());
 
-        $invoices = $this->client->getAccountApi()->getInvoicesForAccount(
-            $this->account->getAccountId(),
-            null,
-            $withItems = 'true'
-        );
+        $invoices = $this->client->getAccountApi()->getInvoicesForAccount($this->account->getAccountId());
         $this->assertCount(1, $invoices);
         $this->assertSame(0.0, $invoices[0]->getAmount());
 
@@ -342,11 +335,7 @@ class ServerInvoiceTest extends KillbillTest
 
         $this->clock->waitForExpectedClause(2, [$this, 'getAccountInvoicesNumber'], [$this->account->getAccountId()]);
 
-        $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount(
-            $this->account->getAccountId(),
-            null,
-            $withItems = 'true'
-        );
+        $invoicesNextMonth = $this->client->getAccountApi()->getInvoicesForAccount($this->account->getAccountId());
         $this->assertCount(2, $invoicesNextMonth);
         $this->assertSame(0.0, $invoicesNextMonth[0]->getAmount());
         $this->assertSame(500.0, $invoicesNextMonth[1]->getAmount());

--- a/test/ServerPaymentTest.php
+++ b/test/ServerPaymentTest.php
@@ -101,14 +101,14 @@ class ServerPaymentTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscription = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
         $this->assertEquals($subscription->getAccountId(), $subscriptionData->getAccountId());
         $this->assertEquals($subscription->getProductName(), $subscriptionData->getProductName());
         $this->assertEquals($subscription->getProductCategory(), $subscriptionData->getProductCategory());
         $this->assertEquals($subscription->getBillingPeriod(), $subscriptionData->getBillingPeriod());
-        $this->assertEquals($subscription->getExternalKey(), $subscriptionData->getExternalKey());
+        $this->assertEquals($subscription->getBundleExternalKey(), $subscriptionData->getBundleExternalKey());
 
         // Move after trial
         $this->clock->addDays(31);
@@ -117,7 +117,7 @@ class ServerPaymentTest extends KillbillTest
         $unpaidInvoices = $this->client->getAccountApi()->getInvoicesForAccount(
             $this->account->getAccountId(),
             null,
-            $withItems = 'true',
+            null,
             null,
             $unpaidOnly = 'true'
         );
@@ -140,14 +140,14 @@ class ServerPaymentTest extends KillbillTest
         $unpaidInvoices = $this->client->getAccountApi()->getInvoicesForAccount(
             $this->account->getAccountId(),
             null,
-            $withItems = 'true',
+            null,
             null,
             $unpaidOnly = 'true'
         );
         $this->assertEmpty($unpaidInvoices);
 
         //TODO: 'true' must be w/o quotes
-        $allInvoices = $this->client->getAccountApi()->getInvoicesForAccount($this->account->getAccountId(), null, $withItems = 'true');
+        $allInvoices = $this->client->getAccountApi()->getInvoicesForAccount($this->account->getAccountId());
         $this->assertCount(2, $allInvoices);
     }
 

--- a/test/ServerSubscriptionTest.php
+++ b/test/ServerSubscriptionTest.php
@@ -85,14 +85,14 @@ class ServerSubscriptionTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscription = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
         $this->assertEquals($subscription->getAccountId(), $subscriptionData->getAccountId());
         $this->assertEquals($subscription->getProductName(), $subscriptionData->getProductName());
         $this->assertEquals($subscription->getProductCategory(), $subscriptionData->getProductCategory());
         $this->assertEquals($subscription->getBillingPeriod(), $subscriptionData->getBillingPeriod());
-        $this->assertEquals($subscription->getExternalKey(), $subscriptionData->getExternalKey());
+        $this->assertEquals($subscription->getBundleExternalKey(), $subscriptionData->getBundleExternalKey());
 
         // Move by a few days -- still in trial -- and change product
         $this->clock->addDays(3);
@@ -132,7 +132,7 @@ class ServerSubscriptionTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscription = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
 
@@ -180,7 +180,7 @@ class ServerSubscriptionTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscription = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
 
@@ -243,14 +243,14 @@ class ServerSubscriptionTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscriptionBase = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
         $this->assertEquals($subscriptionBase->getAccountId(), $subscriptionData->getAccountId());
         $this->assertEquals($subscriptionBase->getProductName(), $subscriptionData->getProductName());
         $this->assertEquals($subscriptionBase->getProductCategory(), $subscriptionData->getProductCategory());
         $this->assertEquals($subscriptionBase->getBillingPeriod(), $subscriptionData->getBillingPeriod());
-        $this->assertEquals($subscriptionBase->getExternalKey(), $subscriptionData->getExternalKey());
+        $this->assertEquals($subscriptionBase->getBundleExternalKey(), $this->externalBundleId);
 
         $this->clock->addDays(3);
 
@@ -260,8 +260,7 @@ class ServerSubscriptionTest extends KillbillTest
         $subscriptionData2->setProductCategory('ADD_ON');
         $subscriptionData2->setBillingPeriod('MONTHLY');
         $subscriptionData2->setPriceList('DEFAULT');
-        $subscriptionData2->setExternalKey($this->externalBundleId);
-        $subscriptionData2->setBundleId($subscriptionBase->getBundleId());
+        $subscriptionData2->setBundleExternalKey($this->externalBundleId);
 
         $subscriptionAO = $this->client->getSubscriptionApi()->createSubscription($subscriptionData2, self::USER, self::REASON, self::COMMENT);
 
@@ -270,7 +269,8 @@ class ServerSubscriptionTest extends KillbillTest
         $this->assertEquals($subscriptionAO->getProductCategory(), $subscriptionData2->getProductCategory());
         $this->assertEquals($subscriptionAO->getBillingPeriod(), $subscriptionData2->getBillingPeriod());
         $this->assertEquals($subscriptionAO->getPriceList(), $subscriptionData2->getPriceList());
-        $this->assertEquals($subscriptionAO->getExternalKey(), $this->externalBundleId);
+        $this->assertEquals($subscriptionAO->getBundleExternalKey(), $this->externalBundleId);
+        $this->assertEquals($subscriptionAO->getBundleId(), $subscriptionBase->getBundleId());
 
         $bundle = $this->client->getBundleApi()->getBundle($subscriptionBase->getBundleId());
         $this->assertNotEmpty($bundle);
@@ -302,7 +302,7 @@ class ServerSubscriptionTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscriptionBase = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
 
@@ -352,7 +352,7 @@ class ServerSubscriptionTest extends KillbillTest
         $subscriptionData->setProductCategory('BASE');
         $subscriptionData->setBillingPeriod('MONTHLY');
         $subscriptionData->setPriceList('DEFAULT');
-        $subscriptionData->setExternalKey($this->externalBundleId);
+        $subscriptionData->setBundleExternalKey($this->externalBundleId);
 
         $subscriptionBase = $this->client->getSubscriptionApi()->createSubscription($subscriptionData, self::USER, self::REASON, self::COMMENT);
 


### PR DESCRIPTION
- Updated CircleCI setup to use killbill v0.22. Before tests were running against v0.20
- Reverted changes from PR https://github.com/killbill/killbill-client-php/pull/47
- Fixed confusion where subscription.ExternalKey was used instead of BundleExternalKey.
- Fixed the use of method getAccountApi.getInvoicesForAccount which signature was changed 
